### PR TITLE
fix BUNDLE_TYPES, BUNDLE_TYPES vars for karura, kusama, moonriver

### DIFF
--- a/karura/docker-compose.yml
+++ b/karura/docker-compose.yml
@@ -25,8 +25,8 @@ services:
       - BLOCK_HEIGHT=747666 # starting block height
       - WS_PROVIDER_ENDPOINT_URI=wss://karura-rpc-3.aca-api.network/ws
       #- TYPES_JSON=types.json
-      - BUNDLE_TYPES=typesBundle.json
-    
+      - BUNDLE_TYPES=/hydra/packages/hydra-indexer/typesBundle.json
+
     volumes:
       #- "./types.json:/hydra/packages/hydra-indexer/types.json"
       - "./typesBundle.json:/hydra/packages/hydra-indexer/typesBundle.json"

--- a/kusama/docker-compose.yml
+++ b/kusama/docker-compose.yml
@@ -24,8 +24,8 @@ services:
       - DB_PORT=5432
       - REDIS_URI=redis://redis:6379/0
       - FORCE_HEIGHT=true
-      - BUNDLE_TYPES=typesBundle.json
-      - TYPES_JSON=types.json
+      - BUNDLE_TYPES=/hydra/packages/hydra-indexer/typesBundle.json
+      - TYPES_JSON=/hydra/packages/hydra-indexer/types.json
       - BLOCK_HEIGHT=9807301 # starting block height
       - WS_PROVIDER_ENDPOINT_URI=wss://kusama-rpc.polkadot.io/
     depends_on:

--- a/moonriver/docker-compose.yml
+++ b/moonriver/docker-compose.yml
@@ -24,8 +24,8 @@ services:
       - FORCE_HEIGHT=true
       - BLOCK_HEIGHT=100000 # starting block height
       - WS_PROVIDER_ENDPOINT_URI=wss://moonriver.api.onfinality.io/public-ws
-      - BUNDLE_TYPES=typesBundle.json
-    
+      - BUNDLE_TYPES=/hydra/packages/hydra-indexer/typesBundle.json
+
     volumes:
       - "./typesBundle.json:/hydra/packages/hydra-indexer/typesBundle.json"
 


### PR DESCRIPTION
Default docker-compose would fail, as these vars don't point where the files are mounted.